### PR TITLE
Fix the install command in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Generate the JWT for App Store Connect API.
 
-```
+```typescript
 import jwt from 'appstore-connect-jwt-generator-core';
 import * as fs from 'fs';
 
@@ -15,9 +15,16 @@ const token = jwt.tokenSync(cert, 'App Store Connect Issuer ID', 'App Store Conn
 
 ## Installation
 
-     $ npm install appstore-connect-jwt-token-generator-core
+```sh
+npm i appstore-connect-jwt-token-generator-core
+```
 
+or
+
+```sh
+yarn add appstore-connect-jwt-token-generator-core
+```
 
 ## Refernce
 
-https://developer.apple.com/documentation/appstoreconnectapi/generating_tokens_for_api_requests
+<https://developer.apple.com/documentation/appstoreconnectapi/generating_tokens_for_api_requests>


### PR DESCRIPTION
Fixed an error in the documentation for https://github.com/poad/appstore-connect-jwt-generator-core/issues/584.